### PR TITLE
fix: configure github pages asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
       content="Portfolio for a Software Engineer with .NET, React, Azure, microservices, and modernization experience."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/assets/og-placeholder.svg" />
+    <meta property="og:image" content="%BASE_URL%assets/og-placeholder.svg" />
     <meta name="twitter:card" content="summary_large_image" />
-    <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="%BASE_URL%assets/favicon.svg" type="image/svg+xml" />
     <title>Juan Diego Mejia Vargas | Software Engineer</title>
     <script>
       try {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import styles from '../App.module.css';
-import { contactLinks, highlights, profile } from '../data/portfolio';
+import { contactLinks, highlights, profile, publicAsset } from '../data/portfolio';
 import { useAnalytics } from '../hooks/useAnalytics';
 
 export function Hero() {
@@ -38,8 +38,13 @@ export function Hero() {
       </div>
       <aside className={styles.heroPanel} aria-label="Career highlights">
         <picture className={styles.profilePhoto}>
-          <source srcSet="/assets/profile-portrait.webp" type="image/webp" />
-          <img src="/assets/profile-portrait.png" alt="Juan Diego Mejia Vargas" loading="eager" decoding="async" />
+          <source srcSet={publicAsset('assets/profile-portrait.webp')} type="image/webp" />
+          <img
+            src={publicAsset('assets/profile-portrait.png')}
+            alt="Juan Diego Mejia Vargas"
+            loading="eager"
+            decoding="async"
+          />
         </picture>
         <div className={styles.availability}>
           <span>Summary</span>

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -32,6 +32,8 @@ export type Certification = {
   details: string;
 };
 
+export const publicAsset = (path: string) => `${import.meta.env.BASE_URL}${path}`;
+
 export const profile = {
   name: 'Juan Diego Mejia Vargas',
   title: 'Software Engineer',
@@ -45,7 +47,7 @@ export const profile = {
   email: 'juandieg0mv22@gmail.com',
   summary:
     'Software Engineer with over 5 years of experience specializing in .NET, React, and the Azure ecosystem. Active contributor to architectural design discussions for robust and scalable microservices and event-driven systems. Proven record modernizing legacy applications by moving them to the cloud, reducing infrastructure costs, and improving scalability and performance.',
-  cvPath: '/assets/Juan_Diego_Mejia_Vargas_CV.pdf',
+  cvPath: publicAsset('assets/Juan_Diego_Mejia_Vargas_CV.pdf'),
 };
 
 export const contactLinks: ContactLink[] = [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: '/Portfolio/',
 });


### PR DESCRIPTION
## Summary
- Set the Vite base path for the GitHub Pages project route.
- Make public asset URLs base-aware for favicon, OpenGraph image, CV, and profile portrait.
- Keep the existing GitHub Pages workflow unchanged.

## Validation
- npm run lint
- npm run build

## Notes
The built output now resolves JS, CSS, and public assets under /Portfolio/ for GitHub Pages.